### PR TITLE
GitHub Actions - Check User Guide Encoding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           ls -l
           expected_encoding="text/plain; charset=utf-16le"
-          encoding=$(file -bi /user-guides/ultimateawuserguide.awh)
+          encoding=$(file -bi ./user-guides/ultimateawuserguide.awh)
           if [ "$encoding" = "$expected_encoding" ]; then 
             echo "Check User Guide Encoding: Pass"
           else 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      - name: Check User Guide Encoding
+        run: |
+          expected_encoding = "text/plain; charset=utf-16le"
+          encoding=$(file -bi /user-guides/ultimateawuserguide.awh)
+          if [ "$encoding" = "$expected_encoding" ]; then 
+            echo "Check User Guide Encoding: Pass"
+          else 
+            echo "Check User Guide Encoding: Encoding $encoding does not match expected encoding $expected_encoding"
+            exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       
       - name: Check User Guide Encoding
         run: |
-          expected_encoding = "text/plain; charset=utf-16le"
+          expected_encoding="text/plain; charset=utf-16le"
           encoding=$(file -bi /user-guides/ultimateawuserguide.awh)
           if [ "$encoding" = "$expected_encoding" ]; then 
             echo "Check User Guide Encoding: Pass"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       
       - name: Check User Guide Encoding
         run: |
+          ls -l
           expected_encoding="text/plain; charset=utf-16le"
           encoding=$(file -bi /user-guides/ultimateawuserguide.awh)
           if [ "$encoding" = "$expected_encoding" ]; then 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
       
       - name: Check User Guide Encoding
         run: |
-          ls -l
           expected_encoding="text/plain; charset=utf-16le"
           encoding=$(file -bi ./user-guides/ultimateawuserguide.awh)
           if [ "$encoding" = "$expected_encoding" ]; then 


### PR DESCRIPTION
## Details

Add a new GitHub Action to check the encoding of the user guide file.  If the encoding changes from `UTF-16 LE BOM` this will cause users to be unable to view the user guide in the AW Browser.